### PR TITLE
Add option: title to set app_name & Change default app_name without .app

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 ![](https://i.ibb.co/k82VnnG/demo.gif)
 
 ## Compatibility
-- Mac OSX
+- macOS
 - Python >= 3.6
 
 ## Dependencies
@@ -29,6 +29,7 @@
 ```
   -i, --icon_file               TEXT    icon to give the app
   -d, --destination_directory   TEXT    directory to create the app in
+  -t, --title                   TEXT    title to display in toolbar
   --help                                print this message and exit
 ```
 ## NOTES

--- a/jar2app.py
+++ b/jar2app.py
@@ -62,7 +62,7 @@ def main(jar_file, icon_file, destination_directory,title):
 
 	file_contents = file_contents \
 		.replace("[APP_JAR]", f"{app_name}.jar") \
-		.replace("[APP_NAME]", title if title else app_name)
+		.replace("[APP_NAME]", title if title else jar_file.stem)
 	
 	with open(app_runner, "br+") as file:
 		file.truncate(0)

--- a/jar2app.py
+++ b/jar2app.py
@@ -24,7 +24,10 @@ from callbacks import *
               default=None,
               callback=check_destination_directory,
               help="directory to create the app in")
-def main(jar_file, icon_file, destination_directory):
+@click.option("-t","--title",
+			default=None,
+			help="title to display in toolbar")
+def main(jar_file, icon_file, destination_directory,title):
 	# ---------------------------------------------- setup app variables -----------------------------------------------
 	jar_file = Path(jar_file)
 	jar_file_parent_directory = Path(dirname(jar_file.absolute()))
@@ -59,12 +62,11 @@ def main(jar_file, icon_file, destination_directory):
 
 	file_contents = file_contents \
 		.replace("[APP_JAR]", f"{app_name}.jar") \
-		.replace("[APP_NAME]", app_name)
-
+		.replace("[APP_NAME]", title if title else app_name)
+	
 	with open(app_runner, "br+") as file:
 		file.truncate(0)
 		file.write(bytes(file_contents, "ascii"))
-
 	# ----------------------------------------------- show app in finder -----------------------------------------------
 	call(["open", "-R", app_target_path])
 


### PR DESCRIPTION
Hi, this repo is so good. Recently I am looing for the way to pack jar to app on Apple Silicon, the other jar2apps were not working well or built an intel version or anyother thing else.  but this one works pretty good.
So I do some changes to make it better. 
1. Add an option `title` to set app_name
2. Use `jar_file.stem` as the default app_name to remove .app suffix